### PR TITLE
Fix: Use correct exit codes

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -4,6 +4,6 @@ runs:
   using: "composite"
   steps:
     - shell: bash
-      run: git log | grep WIP
+      run: check-for-wip.sh
     - shell: bash
-      run: git log | grep fixup
+      run: check-for-fixup.sh

--- a/check-for-fixup.sh
+++ b/check-for-fixup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+
+if git log | grep fixup
+then
+  exit 1
+else
+  exit 0
+fi

--- a/check-for-wip.sh
+++ b/check-for-wip.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+
+if git log | grep WIP
+then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
Moves the scripts out of the `action.yaml` to their own shell scripts to allow custom exit codes to be returned.