### PR TITLE
Fix: Checkout repo before running scripts

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -3,6 +3,12 @@ description: Fail a pipeline if commits include WIP or fixup!
 runs:
   using: "composite"
   steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+        token: ${{ secrets.GH_API_TOKEN }}
     - shell: bash
       run: check-for-wip.sh
     - shell: bash


### PR DESCRIPTION
Before this, the action was throwing `line 1: check-for-wip.sh: command not found`.

Hoping that this fixes it 🤞 